### PR TITLE
added option to specify gene_pairs when computing distances

### DIFF
--- a/gene_trajectory/compute_gene_distance_cmd.py
+++ b/gene_trajectory/compute_gene_distance_cmd.py
@@ -38,12 +38,15 @@ def cal_ot_mat(
     :param show_progress_bar: shows a progress bar while running the computation (default: True)
     :param processes:the number of processes to use (defaults to the number of CPUs available)
     """
-    ot_cost = np.loadtxt(path + "/ot_cost.csv", delimiter=",")
-    gene_expr = sio.mmread(path + "/gene_expression.mtx")
+    ot_cost = np.loadtxt(os.path.join(path, "ot_cost.csv"), delimiter=",")
+    gene_expr = sio.mmread(os.path.join(path,"gene_expression.mtx"))
     if issparse(gene_expr):
         gene_expr = gene_expr.todense()
+    gene_pairs_file = os.path.join(path, "gene_pairs.csv")
+    gene_pairs = np.loadtxt(gene_pairs_file, delimiter=",").astype(int) if os.path.isfile(gene_pairs_file) else None
 
-    emd_mat2 = cal_ot_mat_from_numpy(ot_cost=ot_cost, gene_expr=gene_expr, num_iter_max=num_iter_max,
+    emd_mat2 = cal_ot_mat_from_numpy(ot_cost=ot_cost, gene_expr=gene_expr,
+                                     gene_pairs=gene_pairs, num_iter_max=num_iter_max,
                                      show_progress_bar=show_progress_bar, processes=processes)
     np.savetxt(path + "/emd.csv", emd_mat2, delimiter=",")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "gene-trajectory"
-version = "0.1.4"
+version = "0.1.5"
 description = "Compute gene trajectories"
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/tests/test_compute_gene_distance_cmd.py
+++ b/tests/test_compute_gene_distance_cmd.py
@@ -24,6 +24,8 @@ class DiffusionMapTestCase(unittest.TestCase):
         [0.8, 0.0, 0.9],
         [1.0, 0.9, 0.0]])
 
+    gene_pairs = np.array([[0, 1], [1, 1], [2, 1]], dtype=int)
+
     def test_compute_gene_distance_cmd(self):
         with TemporaryDirectory() as d:
             np.savetxt(os.path.join(d, 'ot_cost.csv'), self.gdm, delimiter=',')
@@ -33,6 +35,20 @@ class DiffusionMapTestCase(unittest.TestCase):
 
             res = np.loadtxt(d + "/emd.csv", delimiter=",")
             np.testing.assert_almost_equal(res, self.expected_emd, decimal=6)
+
+    def test_cal_ot_mat_gene_pairs(self):
+        exp = self.expected_emd.copy()
+        exp[0, 2] = exp[2, 0] = 900
+
+        with TemporaryDirectory() as d:
+            np.savetxt(os.path.join(d, 'ot_cost.csv'), self.gdm, delimiter=',')
+            sio.mmwrite(os.path.join(d, 'gene_expression.mtx'), coo_matrix(self.gem.T))
+            np.savetxt(os.path.join(d, 'gene_pairs.csv'), self.gene_pairs, fmt='%d', delimiter=',')
+
+            cal_ot_mat(d, show_progress_bar=False)
+
+            res = np.loadtxt(d + "/emd.csv", delimiter=",")
+            np.testing.assert_almost_equal(res, exp, decimal=6)
 
 
 if __name__ == '__main__':

--- a/tests/test_gene_distance_shared.py
+++ b/tests/test_gene_distance_shared.py
@@ -22,9 +22,20 @@ class GeneDistanceSharedTestCase(unittest.TestCase):
         [0.8, 0.0, 0.9],
         [1.0, 0.9, 0.0]])
 
+    gene_pairs = [(0, 1), (1, 1), (2, 1)]
+
     def test_gene_distance_shared(self):
         mt = cal_ot_mat(ot_cost=self.gdm, gene_expr=self.gem.T, show_progress_bar=False)
         np.testing.assert_almost_equal(self.expected_emd, mt, 6)
+
+    def test_cal_ot_mat_gene_pairs(self):
+        exp = self.expected_emd.copy()
+        exp[0, 2] = exp[2, 0] = 900
+
+        mt = cal_ot_mat(ot_cost=self.gdm, gene_expr=self.gem.T,
+                        gene_pairs=self.gene_pairs,
+                        show_progress_bar=False)
+        np.testing.assert_almost_equal(exp, mt, 6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Notes:
- the matrix should contain int, not floats
- indexes are 0-based (which is more Pythonic)
```
if(!reticulate::virtualenv_exists('gene_trajectory')){
  reticulate::virtualenv_create('gene_trajectory', packages=c('gene_trajectory'))
}
reticulate::use_virtualenv('gene_trajectory')



cal_ot_mat_from_numpy <- reticulate::import('gene_trajectory.compute_gene_distance_cmd')$cal_ot_mat_from_numpy

gdm <- matrix(c(0, 1, 2, 1, 0, 2, 2, 2, 1), nrow = 3)
gem <- matrix(c(.3, .1, .6, .2, .3, .5,.6, .2, .2), nrow = 3)
exp <- matrix(c(0.0, 0.8, 1.0, 0.8, 0.0, 0.9, 1.0, 0.9, 0.0), nrow = 3)
pairs <- matrix(c(0L, 1L, 1L, 2L), ncol=2) 
cal_ot_mat_from_numpy(ot_cost = gdm, gene_expr = gem, gene_pairs=pairs, show_progress_bar = FALSE)

```

which returns
```
      [,1] [,2]  [,3]
[1,]   0.0  0.8 900.0
[2,]   0.8  0.0   0.9
[3,] 900.0  0.9   0.0
```